### PR TITLE
boundary case support (min max same vals)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 'use strict';
 
-module.exports = function(range, value) {
-  return (value - range[0]) / (range[1] - range[0]);
+module.exports = function(range, value, rangeWidthZeroDefault) {
+  if (range[0] != range[1]) {
+    return (value - range[0]) / (range[1] - range[0]);
+  }
+  else {
+    return (typeof rangeWidthZeroDefault != "undefined") ? rangeWidthZeroDefault : 0.5
+  }
 };


### PR DESCRIPTION
when min and max values in the range are equal, the function returns NaN.
However a user may want to call for ex:
normalize([100, 100], 100) 
and get either 0.5, or 0, or 1, or something else.